### PR TITLE
fix: Makes token available downstream when using refresh token

### DIFF
--- a/R/shiny.R
+++ b/R/shiny.R
@@ -58,6 +58,7 @@ internal_add_auth_layers <- function(config, tower) {
           promises::then(
             token,
             onFulfilled = function(token) {
+              req$TOKEN <- token
               response <- req$NEXT(req)
               response$headers <- append(
                 response$headers,


### PR DESCRIPTION
* Closes #32 